### PR TITLE
Adding matrix strategy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,13 @@ on:
 jobs:
   check-application:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.14','1.15'] 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: ${{ matrix.go }}
       - run: go test
       - run: go run math.go


### PR DESCRIPTION
## Motivo da alteração

Quando definimos uma estratégia de matriz, permitimos que o job seja executado com diferentes parâmetros paralelamente.

## O que foi feito

Alteração do JOB:

```yaml
jobs:
  check-application:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        go: ['1.14','1.15'] 
    steps:
      - uses: actions/checkout@v2
      - uses: actions/setup-go@v2
        with:
          go-version: ${{ matrix.go }}
      - run: go test
      - run: go run math.go
```

### Pipeline em execução:
![Screenshot 2024-06-22 at 12 10 57](https://github.com/lucasalvess/ci-go/assets/25207782/d216e5e3-b2a9-40f0-9820-d35b57a681c1)
