### PR TITLE
Buildando a imagem Docker na pipeline de CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,13 +6,23 @@ on:
 jobs:
   check-application:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ['1.14','1.15'] 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go }}
+          go-version: 1.15
       - run: go test
       - run: go run math.go
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: lucasalvess97/ci-go:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,16 @@ jobs:
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: true
           tags: lucasalvess97/ci-go:latest


### PR DESCRIPTION
## Motivo da alteração

Podemos usar a nossa pipeline de CI para preparar um build da nossa aplicação: Isso pode ser feito por meio da action https://github.com/marketplace/actions/build-and-push-docker-images



Adicionando os steps:

```yaml
      - name: Set up QEMU
        uses: docker/setup-qemu-action@v3

      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3

      - name: Build and push
        uses: docker/build-push-action@v6
        with:
          context: .
          push: false
          tags: user/app:latest
```


- **Set up QEMU** - Cria um ambiente de emulação docker de execução multiplataforma.
- **Set up Docker Buildx** - Configura o Buildx que prepara o ambiente docker para buildar uma imagem. 
- **Build and push** - Action que pode buildar e disparar o push da imagem docker para um Container Registry.
  - **context** - Caminho para o Dockerfile.
  - **push** - Flag que determina de após o build a imagem deve ser enviada ao CR
  - **tags** - Nome da imagem